### PR TITLE
update test case to ensure shouldUndo sees a string with a /

### DIFF
--- a/replace_test.go
+++ b/replace_test.go
@@ -241,8 +241,8 @@ func TestDiff(t *testing.T) {
 	}
 
 	// URL case
-	orig = "nothing\n// This code was inspired by https://github.com/broady/gogeohash\nnothing"
-	corr = "nothing\n// This code was inspired by https://github.com/broadly/gogeohash\nnothing"
+	orig = "http://github.com"
+	corr = "http://changed.com"
 	out, diffs = DiffLines(orig, corr)
 	if out != orig {
 		t.Errorf("Want %q got %q", orig, out)


### PR DESCRIPTION
@client9 this makes it so this path:

```
        // perhaps a URL
        if strings.Contains(s, "/") {
                return true
        }
```

is actually executed in the tests, since before the string was > 20 chars and was returning true here:

```
        // this is some blob of text that has no spaces for 20 characters!
        // Smells like programming or some base64 mess
        if len(s) > 20 {
                return true
        }
```

(coverage increases by a percentage point with this)