### PR TITLE
Switch to xurls for the url regexp

### DIFF
--- a/url.go
+++ b/url.go
@@ -1,17 +1,11 @@
 package misspell
 
 import (
-	"regexp"
+	"github.com/mvdan/xurls"
 )
-
-// Regexp for URL https://mathiasbynens.be/demo/url-regex
-//
-// original @imme_emosol (54 chars) has trouble with dashes in hostname
-// @(https?|ftp)://(-\.)?([^\s/?\.#-]+\.?)+(/[^\s]*)?$@iS
-var reURL = regexp.MustCompile(`(?i)(https?|ftp)://(-\.)?([^\s/?\.#]+\.?)+(/[^\s]*)?`)
 
 // StripURL attemps to replace URLs with blank spaces, e.g.
 //  "xxx http://foo.com/ yyy -> "xxx          yyyy"
 func StripURL(s string) string {
-	return reURL.ReplaceAllStringFunc(s, replaceWithBlanks)
+	return xurls.Strict.ReplaceAllStringFunc(s, replaceWithBlanks)
 }

--- a/url_test.go
+++ b/url_test.go
@@ -46,6 +46,8 @@ func TestStripURL(t *testing.T) {
 		"http://1337.net",
 		"http://a.b-c.de",
 		"http://223.255.255.254",
+		"mailto:foo@bar.com",
+		"git+https://localhost",
 	}
 
 	for num, tt := range cases {
@@ -56,44 +58,13 @@ func TestStripURL(t *testing.T) {
 	}
 
 	cases = []string{
-		"http://",
-		"http://.",
-		"http://..",
-		"http://../",
-		"http://?",
-		"http://??",
-		"http://??/",
-		"http://#",
-		"http://##",
-		"http://##/",
-		"http://foo.bar?q=Spaces should be encoded",
+		"/",
 		"//",
 		"//a",
 		"///a",
 		"///",
-		"http:///a",
 		"foo.com",
-		"rdar://1234",
-		"h://test",
-		"http:// shouldfail.com",
 		":// should fail",
-		"http://foo.bar/foo(bar)baz quux",
-		"ftps://foo.bar/",
-		//"http://-error-.invalid/",
-		//"http://a.b--c.de/",
-		//"http://-a.b.co",
-		//"http://a.b-.co",
-		//"http://0.0.0.0",
-		//"http://10.1.1.0",
-		//"http://10.1.1.255",
-		//"http://224.1.1.1",
-		//"http://1.1.1.1.1",
-		//"http://123.123.123",
-		//"http://3628126748",
-		"http://.www.foo.bar/",
-		//"http://www.foo.bar./",
-		"http://.www.foo.bar./",
-		//"http://10.1.1.1",
 	}
 
 	for num, tt := range cases {


### PR DESCRIPTION
Avoids having to roll a separate regexp. It's also more aggressive,
matching anything that looks like a URL instead of trying to only match
correct URLs.

All the removed test cases now match as urls and are replaced with
blank space, which is good since they wouldn't be potential misspellings
anyway.