### PR TITLE
add word: "on-premise" -> "on-premises"

### DIFF
--- a/words.go
+++ b/words.go
@@ -14366,6 +14366,7 @@ var DictMain = []string{
 	"omnisicent", "omniscient",
 	"omniverous", "omnivorous",
 	"omnsicient", "omniscient",
+	"on-premise", "on-premises",
 	"onmipotent", "omnipotent",
 	"onmiscient", "omniscient",
 	"operatings", "operations",


### PR DESCRIPTION
Wikipedia says:

> On-premises software (sometimes misspelled "on-premise" or abbreviated as "on-prem")

https://en.wikipedia.org/wiki/On-premises_software