### PR TITLE
'preceding' is not misspell

### DIFF
--- a/replace_test.go
+++ b/replace_test.go
@@ -57,7 +57,6 @@ func TestReplace(t *testing.T) {
 		{"closeing Time", "closing Time"},
 		{" TOOD: foobar", " TODO: foobar"},
 		{" preceed ", " precede "},
-		{"preceeding", "preceding"},
 		{"functionallity", "functionality"},
 	}
 	r := New()

--- a/words.go
+++ b/words.go
@@ -14822,7 +14822,6 @@ var DictMain = []string{
 	"precautios", "precautions",
 	"precedance", "precedence",
 	"precedense", "precedence",
-	"preceeding", "preceding",
 	"precendece", "precedence",
 	"precentage", "percentage",
 	"precentile", "percentile",


### PR DESCRIPTION
'preceding' is detected as misspell of 'preceeding', but actually it's not. So I removed the wrong correction from dictionary.

![2018-11-05 11 15 51](https://user-images.githubusercontent.com/823277/47974376-b34ef500-e0ec-11e8-9bb2-34053ed7d556.png)
