### PR TITLE
Skips symlinks when walking files in a dir

### DIFF
--- a/cmd/misspell/main.go
+++ b/cmd/misspell/main.go
@@ -301,7 +301,7 @@ func main() {
 
 	for _, filename := range args {
 		filepath.Walk(filename, func(path string, info os.FileInfo, err error) error {
-			if err == nil && !info.IsDir() {
+			if err == nil && !info.IsDir() && !isSymlink(info) {
 				c <- path
 			}
 			return nil
@@ -323,4 +323,9 @@ func main() {
 	if count != 0 && *exitError {
 		os.Exit(2)
 	}
+}
+
+// isSymlink returns true if info represents a symlink, false otherwise
+func isSymlink(info os.FileInfo) bool {
+	return info.Mode()&os.ModeSymlink != 0
 }


### PR DESCRIPTION
When walking a path (say, a large `vendor/` directory in a Go repo), it's common to encounter symlinks.  Attempting to stat/read these symlinks leads to spurious errors like the following:

```
2018/12/19 18:15:19 Unable to stat "vendor/github.com/grpc-ecosystem/go-grpc-middleware/auth/README.md": stat vendor/github.com/grpc-ecosystem/go-grpc-middleware/auth/README.md: no such file or directory
2018/12/19 18:15:19 Unable to stat "vendor/github.com/grpc-ecosystem/go-grpc-middleware/logging/README.md": stat vendor/github.com/grpc-ecosystem/go-grpc-middleware/logging/README.md: no such file or directory
```

This PR adds a simple check to see if a file is a symlink before writing it to the channel of files to check.