### PR TITLE
Fix own misspellings

### DIFF
--- a/cmd/misspell/main.go
+++ b/cmd/misspell/main.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	// Note for gometalinter it must be "File:Line:Column: Msg"
-	//  note space beteen ": Msg"
+	//  note space between ": Msg"
 	defaultWriteTmpl = `{{ .Filename }}:{{ .Line }}:{{ .Column }}: corrected "{{ .Original }}" to "{{ .Corrected }}"`
 	defaultReadTmpl  = `{{ .Filename }}:{{ .Line }}:{{ .Column }}: "{{ .Original }}" is a misspelling of "{{ .Corrected }}"`
 	csvTmpl          = `{{ printf "%q" .Filename }},{{ .Line }},{{ .Column }},{{ .Original }},{{ .Corrected }}`

--- a/ignore/glob.go
+++ b/ignore/glob.go
@@ -25,7 +25,7 @@ func NewMultiMatch(matchers []Matcher) *MultiMatch {
 	return &MultiMatch{matchers: matchers}
 }
 
-// Match satifies the Matcher iterface
+// Match satisfies the Matcher iterface
 func (mm *MultiMatch) Match(arg string) bool {
 	// Normal: OR
 	// false, false -> false
@@ -51,7 +51,7 @@ func (mm *MultiMatch) Match(arg string) bool {
 // True returns true
 func (mm *MultiMatch) True() bool { return true }
 
-// MarshalText satifies the ?? interface
+// MarshalText satisfies the encoding.TextMarshaler interface
 func (mm *MultiMatch) MarshalText() ([]byte, error) {
 	return []byte("multi"), nil
 }

--- a/notwords.go
+++ b/notwords.go
@@ -72,7 +72,7 @@ func RemoveHost(s string) string {
 	return reHost.ReplaceAllStringFunc(s, replaceWithBlanks)
 }
 
-// RemoveBackslashEscapes removes characters that are preceeded by a backslash
+// RemoveBackslashEscapes removes characters that are preceded by a backslash
 // commonly found in printf format stringd "\nto"
 func removeBackslashEscapes(s string) string {
 	return reBackslash.ReplaceAllStringFunc(s, replaceWithBlanks)

--- a/url.go
+++ b/url.go
@@ -10,7 +10,7 @@ import (
 // @(https?|ftp)://(-\.)?([^\s/?\.#-]+\.?)+(/[^\s]*)?$@iS
 var reURL = regexp.MustCompile(`(?i)(https?|ftp)://(-\.)?([^\s/?\.#]+\.?)+(/[^\s]*)?`)
 
-// StripURL attemps to replace URLs with blank spaces, e.g.
+// StripURL attempts to replace URLs with blank spaces, e.g.
 //  "xxx http://foo.com/ yyy -> "xxx          yyyy"
 func StripURL(s string) string {
 	return reURL.ReplaceAllStringFunc(s, replaceWithBlanks)


### PR DESCRIPTION
This change fixes several misspellings in the misspell project.
They were found using `misspell` itself.

Fixes #148.