### PR TITLE
Fix backslash escaped bytes and unicode characters

### DIFF
--- a/falsepositives_test.go
+++ b/falsepositives_test.go
@@ -123,6 +123,9 @@ func TestFalsePositives(t *testing.T) {
 		"cantPrepare", // variable name
 		"dontPrepare", // variable name
 		"\\nto",       // https://github.com/client9/misspell/issues/93
+		"\\xadn",
+		"\\udaed",
+		"\\Uaccademic",
 		"4f8b42c22dd3729b519ba6f68d2da7cc5b2d606d05daed5ad5128cc03e6c6358", // https://github.com/client9/misspell/issues/97
 	}
 	r := New()

--- a/notwords.go
+++ b/notwords.go
@@ -9,7 +9,7 @@ import (
 var (
 	reEmail     = regexp.MustCompile(`[a-zA-Z0-9_.%+-]+@[a-zA-Z0-9-.]+\.[a-zA-Z]{2,6}[^a-zA-Z]`)
 	reHost      = regexp.MustCompile(`[a-zA-Z0-9-.]+\.[a-zA-Z]+`)
-	reBackslash = regexp.MustCompile(`\\[a-z]`)
+	reBackslash = regexp.MustCompile(`\\[abfnrtv]`)
 )
 
 // RemovePath attempts to strip away embedded file system paths, e.g.

--- a/notwords_test.go
+++ b/notwords_test.go
@@ -17,6 +17,8 @@ func TestNotWords(t *testing.T) {
 		{"x infinitie.net y", "x               y"},
 		{"(s.svc.GetObject(", "(               ("},
 		{"\\nto", "  to"},
+		{"\\xadn", "\\xadn"},
+		{"\\udead", "\\udead"},
 	}
 	for pos, tt := range cases {
 		got := RemoveNotWords(tt.word)


### PR DESCRIPTION
Fix false positives in strings with backslash escaped bytes and unicode characters, e.g. "\\udaed" was previously changed to "\\udead".