### PR TITLE
Travis CI: Trusty is end of life and the sudo: tag is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-dist: trusty
 group: edge
 language: go
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 group: edge
 language: go
 go:
-    - "1.10"
+    - "1.13"
 git:
   depth: 1
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,17 +2,5 @@
 set -ex
 dep ensure
 go install ./cmd/misspell
-gometalinter \
-  --vendor \
-  --deadline=60s \
-  --disable-all \
-  --enable=vet \
-  --enable=golint \
-  --enable=gofmt \
-  --enable=goimports \
-  --enable=gosimple \
-  --enable=staticcheck \
-  --enable=ineffassign \
-  --exclude=/usr/local/go/src/net/lookup_unix.go \
- ./...
+golangci-lint run
 go test .

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,8 +4,8 @@ set -ex
 # DEP
 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
-# GOMETALINTER
-go get -u github.com/alecthomas/gometalinter && gometalinter --install
+# golangci-lint
+go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # remove the default misspell to make sure
 rm -f `which misspell`


### PR DESCRIPTION
Also gometalinter --> golangci-lint 