### PR TITLE
Fix some misspelled words in the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Usage of misspell:
   -legal
     	Show legal information and exit
   -locale string
-    	Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'
+    	Correct spellings using locale preferences for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'
   -o string
     	output file or [stderr|stdout|] (default "stdout")
   -q	Do not emit misspelling output

--- a/cmd/misspell/main.go
+++ b/cmd/misspell/main.go
@@ -106,7 +106,7 @@ func main() {
 		outFlag     = flag.String("o", "stdout", "output file or [stderr|stdout|]")
 		format      = flag.String("f", "", "'csv', 'sqlite3' or custom Golang template for output")
 		ignores     = flag.String("i", "", "ignore the following corrections, comma separated")
-		locale      = flag.String("locale", "", "Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'")
+		locale      = flag.String("locale", "", "Correct spellings using locale preferences for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'")
 		mode        = flag.String("source", "auto", "Source mode: auto=guess, go=golang source, text=plain or markdown-like text")
 		debugFlag   = flag.Bool("debug", false, "Debug matching, very slow")
 		exitError   = flag.Bool("error", false, "Exit with 2 if misspelling found")


### PR DESCRIPTION
I was using this tool and I noticed some spelling errors in the README and --help flag. The word 'preferences' was spelled 'perferances'.
