### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Usage of misspell:
   -legal
     	Show legal information and exit
   -locale string
-    	Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'
+    	Correct spellings using locale preferences for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'
   -o string
     	output file or [stderr|stdout|] (default "stdout")
   -q	Do not emit misspelling output
@@ -418,7 +418,7 @@ locale would correct "advisor" to "adviser".
 
 *Versioning*  Some type of versioning is needed so reporting mistakes and errors is easier.
 
-*Feedback*  Mistakes would be sent to some server for agregation and feedback review.
+*Feedback*  Mistakes would be sent to some server for aggregation and feedback review.
 
 *Contractions and Apostrophes* This would optionally correct "isnt" to
 "isn't", etc.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -40,7 +40,7 @@ func BenchmarkCleanString(b *testing.B) {
 		count += len(diffs)
 	}
 
-	// prevent compilier optimizations
+	// prevent compiler optimizations
 	tmpCount = count
 	tmp = updated
 }
@@ -90,7 +90,7 @@ func BenchmarkDirtyString(b *testing.B) {
 		count += len(diffs)
 	}
 
-	// prevent compilier optimizations
+	// prevent compiler optimizations
 	tmpCount = count
 	tmp = updated
 }

--- a/cmd/misspell/main.go
+++ b/cmd/misspell/main.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	// Note for gometalinter it must be "File:Line:Column: Msg"
-	//  note space beteen ": Msg"
+	//  note space between ": Msg"
 	defaultWriteTmpl = `{{ .Filename }}:{{ .Line }}:{{ .Column }}: corrected "{{ .Original }}" to "{{ .Corrected }}"`
 	defaultReadTmpl  = `{{ .Filename }}:{{ .Line }}:{{ .Column }}: "{{ .Original }}" is a misspelling of "{{ .Corrected }}"`
 	csvTmpl          = `{{ printf "%q" .Filename }},{{ .Line }},{{ .Column }},{{ .Original }},{{ .Corrected }}`
@@ -106,7 +106,7 @@ func main() {
 		outFlag     = flag.String("o", "stdout", "output file or [stderr|stdout|]")
 		format      = flag.String("f", "", "'csv', 'sqlite3' or custom Golang template for output")
 		ignores     = flag.String("i", "", "ignore the following corrections, comma separated")
-		locale      = flag.String("locale", "", "Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'")
+		locale      = flag.String("locale", "", "Correct spellings using locale preferences for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'")
 		mode        = flag.String("source", "auto", "Source mode: auto=guess, go=golang source, text=plain or markdown-like text")
 		debugFlag   = flag.Bool("debug", false, "Debug matching, very slow")
 		exitError   = flag.Bool("error", false, "Exit with 2 if misspelling found")
@@ -194,7 +194,7 @@ func main() {
 		defaultRead = template.Must(template.New("defaultRead").Parse(defaultReadTmpl))
 	}
 
-	// we cant't just write to os.Stdout directly since we have multiple goroutine
+	// we can't just write to os.Stdout directly since we have multiple goroutine
 	// all writing at the same time causing broken output.  Log is routine safe.
 	// we see it so it doesn't use a prefix or include a time stamp.
 	switch {

--- a/ignore/glob.go
+++ b/ignore/glob.go
@@ -25,7 +25,7 @@ func NewMultiMatch(matchers []Matcher) *MultiMatch {
 	return &MultiMatch{matchers: matchers}
 }
 
-// Match satifies the Matcher iterface
+// Match satisfies the Matcher interface
 func (mm *MultiMatch) Match(arg string) bool {
 	// Normal: OR
 	// false, false -> false
@@ -51,7 +51,7 @@ func (mm *MultiMatch) Match(arg string) bool {
 // True returns true
 func (mm *MultiMatch) True() bool { return true }
 
-// MarshalText satifies the ?? interface
+// MarshalText satisfies the ?? interface
 func (mm *MultiMatch) MarshalText() ([]byte, error) {
 	return []byte("multi"), nil
 }

--- a/legal.go
+++ b/legal.go
@@ -3,7 +3,7 @@ package misspell
 
 // Legal provides licensing info.
 const Legal = `
-Execept where noted below, the source code for misspell is
+Except where noted below, the source code for misspell is
 copyright Nick Galbreath and distribution is allowed under a
 MIT license.  See the following for details:
 

--- a/mime.go
+++ b/mime.go
@@ -17,7 +17,7 @@ import (
 //
 // Golang's internal table is very small and can't be
 // relied on.  Even then things like ".js" have a mime
-// type of "application/javascipt" which isn't very helpful.
+// type of "application/javascript" which isn't very helpful.
 // "[x]" means we have  sniff test and suffix test should be eliminated
 var binary = map[string]bool{
 	".a":     true, // [ ] archive
@@ -150,7 +150,7 @@ func isTextFile(raw []byte) bool {
 // uses a sniffer to determine if the file is text or not.
 // Using file extensions isn't great, but probably
 // good enough for real-world use.
-// Golang's built in sniffer is problematic for differnet reasons.  It's
+// Golang's built in sniffer is problematic for different reasons.  It's
 // optimized for HTML, and is very limited in detection.  It would be good
 // to explicitly add some tests for ELF/DWARF formats to make sure we never
 // corrupt binary files.

--- a/notwords.go
+++ b/notwords.go
@@ -72,7 +72,7 @@ func RemoveHost(s string) string {
 	return reHost.ReplaceAllStringFunc(s, replaceWithBlanks)
 }
 
-// RemoveBackslashEscapes removes characters that are preceeded by a backslash
+// RemoveBackslashEscapes removes characters that are preceded by a backslash
 // commonly found in printf format stringd "\nto"
 func removeBackslashEscapes(s string) string {
 	return reBackslash.ReplaceAllStringFunc(s, replaceWithBlanks)

--- a/replace.go
+++ b/replace.go
@@ -70,7 +70,7 @@ func (r *Replacer) RemoveRule(ignore []string) {
 
 // AddRuleList appends new rules.
 // Input is in the same form as Strings.Replacer: [ old1, new1, old2, new2, ....]
-// Note: does not check for duplictes
+// Note: does not check for duplicates
 func (r *Replacer) AddRuleList(additions []string) {
 	r.engine = nil
 	r.Replacements = append(r.Replacements, additions...)

--- a/url.go
+++ b/url.go
@@ -10,7 +10,7 @@ import (
 // @(https?|ftp)://(-\.)?([^\s/?\.#-]+\.?)+(/[^\s]*)?$@iS
 var reURL = regexp.MustCompile(`(?i)(https?|ftp)://(-\.)?([^\s/?\.#]+\.?)+(/[^\s]*)?`)
 
-// StripURL attemps to replace URLs with blank spaces, e.g.
+// StripURL attempts to replace URLs with blank spaces, e.g.
 //  "xxx http://foo.com/ yyy -> "xxx          yyyy"
 func StripURL(s string) string {
 	return reURL.ReplaceAllStringFunc(s, replaceWithBlanks)


### PR DESCRIPTION
Typos found by [codespell](https://github.com/codespell-project/codespell).

Mostly duplicate of #117, #149, #177, except for:
`agregation` → `aggregation`
`compilier` → `compiler`
`cant't` → `can't`
`Execept` → `Except`
`application/javascipt` → `application/javascript`
`differnet` → `different`
`duplictes` → `duplicates`